### PR TITLE
Consolidate Metric Observers

### DIFF
--- a/internal/app/metrics_observer.go
+++ b/internal/app/metrics_observer.go
@@ -24,6 +24,7 @@ type MetricsIn struct {
 	KafkaPublishLatency    kit.Histogram `name:"kafka_publish_latency_seconds"`
 	Panics                 kit.Counter   `name:"panics_total"`
 	UnknownMetrics         kit.Counter   `name:"unknown_metrics_total"`
+	MetricPanics           kit.Counter   `name:"metric_panics_total"`
 }
 
 type metricsObserverIn struct {
@@ -50,6 +51,7 @@ var MetricObserversModule = fx.Module("metrics_observers",
 				KafkaPublished:         in.KafkaPublished,
 				KafkaPublishLatency:    in.KafkaPublishLatency,
 				UnknownMetrics:         in.UnknownMetrics,
+				MetricPanics:           in.MetricPanics,
 			}
 		}),
 	fx.Provide(

--- a/internal/app/metrics_observer.go
+++ b/internal/app/metrics_observer.go
@@ -23,6 +23,7 @@ type MetricsIn struct {
 	KafkaPublished         kit.Counter   `name:"kafka_messages_published_total"`
 	KafkaPublishLatency    kit.Histogram `name:"kafka_publish_latency_seconds"`
 	Panics                 kit.Counter   `name:"panics_total"`
+	UnknownMetrics         kit.Counter   `name:"unknown_metrics_total"`
 }
 
 type metricsObserverIn struct {
@@ -48,6 +49,7 @@ var MetricObserversModule = fx.Module("metrics_observers",
 				Panics:                 in.Panics,
 				KafkaPublished:         in.KafkaPublished,
 				KafkaPublishLatency:    in.KafkaPublishLatency,
+				UnknownMetrics:         in.UnknownMetrics,
 			}
 		}),
 	fx.Provide(

--- a/internal/metrics/fx.go
+++ b/internal/metrics/fx.go
@@ -45,6 +45,7 @@ const (
 	KafkaPublishLatency    = "kafka_publish_latency_seconds"
 	KafkaBufferUtilization = "kafka_buffer_utilization_percentage"
 	Panics                 = "panics_total"
+	UnknownMetrics         = "unknown_metrics_total"
 )
 
 // labels

--- a/internal/metrics/fx.go
+++ b/internal/metrics/fx.go
@@ -46,6 +46,7 @@ const (
 	KafkaBufferUtilization = "kafka_buffer_utilization_percentage"
 	Panics                 = "panics_total"
 	UnknownMetrics         = "unknown_metrics_total"
+	MetricPanics           = "metric_panics_total"
 )
 
 // labels

--- a/internal/metrics/fx.go
+++ b/internal/metrics/fx.go
@@ -60,6 +60,8 @@ const (
 	TopicShardStrategyLabel = "topic_shard_strategy"
 	OutcomeLabel            = "outcome"
 	PanicTypeLabel          = "panic_type"
+	MetricNameLabel         = "metric_name"
+	MetricTypeLabel         = "metric_type"
 )
 
 // canned values
@@ -130,11 +132,22 @@ var fxMetrics = []metricDefinition{
 		GaugeFunc: getKafkaBufferUtilization,
 	},
 	{
-		Type: COUNTER,
-		Name: Panics,
-		Help: "Total number of panics encountered",
-
+		Type:   COUNTER,
+		Name:   Panics,
+		Help:   "Total number of panics encountered",
 		Labels: PanicTypeLabel,
+	},
+	{
+		Type:   COUNTER,
+		Name:   UnknownMetrics,
+		Help:   "Number of events with unknown metric names",
+		Labels: fmt.Sprintf("%s,%s", MetricNameLabel, MetricTypeLabel),
+	},
+	{
+		Type:   COUNTER,
+		Name:   MetricPanics,
+		Help:   "Number of panics encountered while handling metrics events",
+		Labels: fmt.Sprintf("%s,%s", MetricNameLabel, MetricTypeLabel),
 	},
 }
 

--- a/internal/metrics/observer.go
+++ b/internal/metrics/observer.go
@@ -5,52 +5,91 @@ package metrics
 
 import (
 	"fmt"
+
+	kit "github.com/go-kit/kit/metrics"
 )
 
-type Observer struct {
-	metric     Metric
-	name       string
-	metricType metricType
+// Generic observers that can handle multiple metrics of the same type
+type CounterObserver struct {
+	counters map[string]kit.Counter
 }
 
-func NewObserver(name string, metricType metricType, metric Metric) *Observer {
-	return &Observer{
-		name:       name,
-		metricType: metricType,
-		metric:     metric,
-	}
+type GaugeObserver struct {
+	gauges map[string]kit.Gauge
 }
 
-func (l *Observer) HandleEvent(event Event) {
-	// Catch any panics from Prometheus/go-kit metrics
+type HistogramObserver struct {
+	histograms map[string]kit.Histogram
+}
+
+// NewCounterObserver creates a new observer for counter metrics
+func NewCounterObserver(counters map[string]kit.Counter) *CounterObserver {
+	return &CounterObserver{counters: counters}
+}
+
+// NewGaugeObserver creates a new observer for gauge metrics
+func NewGaugeObserver(gauges map[string]kit.Gauge) *GaugeObserver {
+	return &GaugeObserver{gauges: gauges}
+}
+
+// NewHistogramObserver creates a new observer for histogram metrics
+func NewHistogramObserver(histograms map[string]kit.Histogram) *HistogramObserver {
+	return &HistogramObserver{histograms: histograms}
+}
+
+func (c *CounterObserver) HandleEvent(event Event) {
 	defer func() {
 		if r := recover(); r != nil {
-			fmt.Printf("ERROR: Prometheus panic for metric '%s': %v (labels: %v)\n", l.name, r, event.Labels)
+			fmt.Printf("ERROR: Prometheus panic for counter metric '%s': %v (labels: %v)\n", event.Name, r, event.Labels)
 		}
 	}()
 
-	if l.name != event.Name {
+	counter, ok := c.counters[event.Name]
+	if !ok {
+		// Silently ignore unknown metrics
 		return
 	}
-
-	switch l.metricType {
-	case COUNTER:
-		if l.metric.counter == nil {
-			fmt.Printf("ERROR: counter for metric '%s' is nil\n", l.name)
-			return
-		}
-		l.metric.counter.With(event.Labels...).Add(event.Value)
-	case GAUGE:
-		if l.metric.gauge == nil {
-			fmt.Printf("ERROR: gauge for metric '%s' is nil\n", l.name)
-			return
-		}
-		l.metric.gauge.With(event.Labels...).Set(event.Value)
-	case HISTOGRAM:
-		if l.metric.histogram == nil {
-			fmt.Printf("ERROR: histogram for metric '%s' is nil\n", l.name)
-			return
-		}
-		l.metric.histogram.With(event.Labels...).Observe(event.Value)
+	if counter == nil {
+		fmt.Printf("ERROR: counter for metric '%s' is nil\n", event.Name)
+		return
 	}
+	counter.With(event.Labels...).Add(event.Value)
+}
+
+func (g *GaugeObserver) HandleEvent(event Event) {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Printf("ERROR: Prometheus panic for gauge metric '%s': %v (labels: %v)\n", event.Name, r, event.Labels)
+		}
+	}()
+
+	gauge, ok := g.gauges[event.Name]
+	if !ok {
+		// Silently ignore unknown metrics
+		return
+	}
+	if gauge == nil {
+		fmt.Printf("ERROR: gauge for metric '%s' is nil\n", event.Name)
+		return
+	}
+	gauge.With(event.Labels...).Set(event.Value)
+}
+
+func (h *HistogramObserver) HandleEvent(event Event) {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Printf("ERROR: Prometheus panic for histogram metric '%s': %v (labels: %v)\n", event.Name, r, event.Labels)
+		}
+	}()
+
+	histogram, ok := h.histograms[event.Name]
+	if !ok {
+		// Silently ignore unknown metrics
+		return
+	}
+	if histogram == nil {
+		fmt.Printf("ERROR: histogram for metric '%s' is nil\n", event.Name)
+		return
+	}
+	histogram.With(event.Labels...).Observe(event.Value)
 }

--- a/internal/metrics/observer.go
+++ b/internal/metrics/observer.go
@@ -11,30 +11,33 @@ import (
 
 // Generic observers that can handle multiple metrics of the same type
 type CounterObserver struct {
-	counters map[string]kit.Counter
+	counters     map[string]kit.Counter
+	panicCounter kit.Counter
 }
 
 type GaugeObserver struct {
-	gauges map[string]kit.Gauge
+	gauges       map[string]kit.Gauge
+	panicCounter kit.Counter
 }
 
 type HistogramObserver struct {
-	histograms map[string]kit.Histogram
+	histograms   map[string]kit.Histogram
+	panicCounter kit.Counter
 }
 
 // NewCounterObserver creates a new observer for counter metrics
-func NewCounterObserver(counters map[string]kit.Counter) *CounterObserver {
-	return &CounterObserver{counters: counters}
+func NewCounterObserver(counters map[string]kit.Counter, panicCounter kit.Counter) *CounterObserver {
+	return &CounterObserver{counters: counters, panicCounter: panicCounter}
 }
 
 // NewGaugeObserver creates a new observer for gauge metrics
-func NewGaugeObserver(gauges map[string]kit.Gauge) *GaugeObserver {
-	return &GaugeObserver{gauges: gauges}
+func NewGaugeObserver(gauges map[string]kit.Gauge, panicCounter kit.Counter) *GaugeObserver {
+	return &GaugeObserver{gauges: gauges, panicCounter: panicCounter}
 }
 
 // NewHistogramObserver creates a new observer for histogram metrics
-func NewHistogramObserver(histograms map[string]kit.Histogram) *HistogramObserver {
-	return &HistogramObserver{histograms: histograms}
+func NewHistogramObserver(histograms map[string]kit.Histogram, panicCounter kit.Counter) *HistogramObserver {
+	return &HistogramObserver{histograms: histograms, panicCounter: panicCounter}
 }
 
 // HandleEvent processes counter events
@@ -42,6 +45,9 @@ func (c *CounterObserver) HandleEvent(event Event) bool {
 	defer func() {
 		if r := recover(); r != nil {
 			fmt.Printf("ERROR: Prometheus panic for counter metric '%s': %v (labels: %v)\n", event.Name, r, event.Labels)
+			if c.panicCounter != nil {
+				c.panicCounter.With("metric_name", event.Name, "metric_type", "counter").Add(1)
+			}
 		}
 	}()
 
@@ -62,6 +68,9 @@ func (g *GaugeObserver) HandleEvent(event Event) bool {
 	defer func() {
 		if r := recover(); r != nil {
 			fmt.Printf("ERROR: Prometheus panic for gauge metric '%s': %v (labels: %v)\n", event.Name, r, event.Labels)
+			if g.panicCounter != nil {
+				g.panicCounter.With("metric_name", event.Name, "metric_type", "gauge").Add(1)
+			}
 		}
 	}()
 
@@ -82,6 +91,9 @@ func (h *HistogramObserver) HandleEvent(event Event) bool {
 	defer func() {
 		if r := recover(); r != nil {
 			fmt.Printf("ERROR: Prometheus panic for histogram metric '%s': %v (labels: %v)\n", event.Name, r, event.Labels)
+			if h.panicCounter != nil {
+				h.panicCounter.With("metric_name", event.Name, "metric_type", "histogram").Add(1)
+			}
 		}
 	}()
 

--- a/internal/metrics/observer.go
+++ b/internal/metrics/observer.go
@@ -46,7 +46,7 @@ func (c *CounterObserver) HandleEvent(event Event) bool {
 		if r := recover(); r != nil {
 			fmt.Printf("ERROR: Prometheus panic for counter metric '%s': %v (labels: %v)\n", event.Name, r, event.Labels)
 			if c.panicCounter != nil {
-				c.panicCounter.With("metric_name", event.Name, "metric_type", "counter").Add(1)
+				c.panicCounter.With(MetricNameLabel, event.Name, MetricTypeLabel, "counter").Add(1)
 			}
 		}
 	}()
@@ -69,7 +69,7 @@ func (g *GaugeObserver) HandleEvent(event Event) bool {
 		if r := recover(); r != nil {
 			fmt.Printf("ERROR: Prometheus panic for gauge metric '%s': %v (labels: %v)\n", event.Name, r, event.Labels)
 			if g.panicCounter != nil {
-				g.panicCounter.With("metric_name", event.Name, "metric_type", "gauge").Add(1)
+				g.panicCounter.With(MetricNameLabel, event.Name, MetricTypeLabel, "gauge").Add(1)
 			}
 		}
 	}()
@@ -92,7 +92,7 @@ func (h *HistogramObserver) HandleEvent(event Event) bool {
 		if r := recover(); r != nil {
 			fmt.Printf("ERROR: Prometheus panic for histogram metric '%s': %v (labels: %v)\n", event.Name, r, event.Labels)
 			if h.panicCounter != nil {
-				h.panicCounter.With("metric_name", event.Name, "metric_type", "histogram").Add(1)
+				h.panicCounter.With(MetricNameLabel, event.Name, MetricTypeLabel, "histogram").Add(1)
 			}
 		}
 	}()

--- a/internal/metrics/observer.go
+++ b/internal/metrics/observer.go
@@ -37,7 +37,8 @@ func NewHistogramObserver(histograms map[string]kit.Histogram) *HistogramObserve
 	return &HistogramObserver{histograms: histograms}
 }
 
-func (c *CounterObserver) HandleEvent(event Event) {
+// HandleEvent processes counter events
+func (c *CounterObserver) HandleEvent(event Event) bool {
 	defer func() {
 		if r := recover(); r != nil {
 			fmt.Printf("ERROR: Prometheus panic for counter metric '%s': %v (labels: %v)\n", event.Name, r, event.Labels)
@@ -46,17 +47,18 @@ func (c *CounterObserver) HandleEvent(event Event) {
 
 	counter, ok := c.counters[event.Name]
 	if !ok {
-		// Silently ignore unknown metrics
-		return
+		return false
 	}
 	if counter == nil {
 		fmt.Printf("ERROR: counter for metric '%s' is nil\n", event.Name)
-		return
+		return false
 	}
 	counter.With(event.Labels...).Add(event.Value)
+	return true
 }
 
-func (g *GaugeObserver) HandleEvent(event Event) {
+// HandleEvent processes gauge events
+func (g *GaugeObserver) HandleEvent(event Event) bool {
 	defer func() {
 		if r := recover(); r != nil {
 			fmt.Printf("ERROR: Prometheus panic for gauge metric '%s': %v (labels: %v)\n", event.Name, r, event.Labels)
@@ -65,17 +67,18 @@ func (g *GaugeObserver) HandleEvent(event Event) {
 
 	gauge, ok := g.gauges[event.Name]
 	if !ok {
-		// Silently ignore unknown metrics
-		return
+		return false
 	}
 	if gauge == nil {
 		fmt.Printf("ERROR: gauge for metric '%s' is nil\n", event.Name)
-		return
+		return false
 	}
 	gauge.With(event.Labels...).Set(event.Value)
+	return true
 }
 
-func (h *HistogramObserver) HandleEvent(event Event) {
+// HandleEvent processes histogram events
+func (h *HistogramObserver) HandleEvent(event Event) bool {
 	defer func() {
 		if r := recover(); r != nil {
 			fmt.Printf("ERROR: Prometheus panic for histogram metric '%s': %v (labels: %v)\n", event.Name, r, event.Labels)
@@ -84,12 +87,12 @@ func (h *HistogramObserver) HandleEvent(event Event) {
 
 	histogram, ok := h.histograms[event.Name]
 	if !ok {
-		// Silently ignore unknown metrics
-		return
+		return false
 	}
 	if histogram == nil {
 		fmt.Printf("ERROR: histogram for metric '%s' is nil\n", event.Name)
-		return
+		return false
 	}
 	histogram.With(event.Labels...).Observe(event.Value)
+	return true
 }

--- a/internal/metrics/observer_test.go
+++ b/internal/metrics/observer_test.go
@@ -6,425 +6,259 @@ package metrics
 import (
 	"testing"
 
+	kit "github.com/go-kit/kit/metrics"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/suite"
 )
 
-type ObserverTestSuite struct {
-	suite.Suite
-}
-
-func TestObserverTestSuite(t *testing.T) {
-	suite.Run(t, new(ObserverTestSuite))
-}
-
-// TestNewObserver tests creating new observers
-func (s *ObserverTestSuite) TestNewObserver() {
+func TestCounterObserver(t *testing.T) {
 	tests := []struct {
-		name         string
-		metricName   string
-		metricType   metricType
-		expectedName string
-		expectedType metricType
-		hasCounter   bool
-		hasGauge     bool
-		hasHistogram bool
+		name          string
+		setupCounters func() map[string]kit.Counter
+		events        []Event
+		shouldPanic   bool
+		expectPanic   bool
+		verifyMocks   bool
 	}{
 		{
-			name:         "counter observer",
-			metricName:   "test_counter",
-			metricType:   COUNTER,
-			expectedName: "test_counter",
-			expectedType: COUNTER,
-			hasCounter:   true,
+			name: "handle multiple counter events",
+			setupCounters: func() map[string]kit.Counter {
+				counter1 := &MockCounter{}
+				counter1.On("With", []string{"label1", "value1"}).Return(counter1)
+				counter1.On("Add", 5.0).Return()
+
+				counter2 := &MockCounter{}
+				counter2.On("With", []string{"label2", "value2"}).Return(counter2)
+				counter2.On("Add", 10.0).Return()
+
+				return map[string]kit.Counter{
+					"test_counter_1": counter1,
+					"test_counter_2": counter2,
+				}
+			},
+			events: []Event{
+				{Name: "test_counter_1", Labels: []string{"label1", "value1"}, Value: 5.0},
+				{Name: "test_counter_2", Labels: []string{"label2", "value2"}, Value: 10.0},
+				{Name: "unknown_counter", Labels: []string{"label3", "value3"}, Value: 15.0},
+			},
+			verifyMocks: true,
 		},
 		{
-			name:         "gauge observer",
-			metricName:   "test_gauge",
-			metricType:   GAUGE,
-			expectedName: "test_gauge",
-			expectedType: GAUGE,
-			hasGauge:     true,
+			name: "handle nil counter gracefully",
+			setupCounters: func() map[string]kit.Counter {
+				return map[string]kit.Counter{
+					"test_counter": nil,
+				}
+			},
+			events: []Event{
+				{Name: "test_counter", Labels: []string{}, Value: 1.0},
+			},
+			shouldPanic: false,
 		},
 		{
-			name:         "histogram observer",
-			metricName:   "test_histogram",
-			metricType:   HISTOGRAM,
-			expectedName: "test_histogram",
-			expectedType: HISTOGRAM,
-			hasHistogram: true,
+			name: "handle empty counters map",
+			setupCounters: func() map[string]kit.Counter {
+				return map[string]kit.Counter{}
+			},
+			events: []Event{
+				{Name: "any_counter", Labels: []string{}, Value: 1.0},
+			},
+			shouldPanic: false,
+		},
+		{
+			name: "recover from panic gracefully",
+			setupCounters: func() map[string]kit.Counter {
+				counter := &MockCounter{}
+				counter.On("With", []string{"label1", "value1"}).Return(counter)
+				counter.On("Add", 5.0).Run(func(args mock.Arguments) {
+					panic("test panic")
+				})
+				return map[string]kit.Counter{
+					"test_counter": counter,
+				}
+			},
+			events: []Event{
+				{Name: "test_counter", Labels: []string{"label1", "value1"}, Value: 5.0},
+			},
+			expectPanic: false,
+			verifyMocks: true,
 		},
 	}
 
 	for _, tt := range tests {
-		s.Run(tt.name, func() {
-			var metric Metric
-			if tt.hasCounter {
-				metric.counter = &MockCounter{}
-			}
-			if tt.hasGauge {
-				metric.gauge = &MockGauge{}
-			}
-			if tt.hasHistogram {
-				metric.histogram = &MockHistogram{}
+		t.Run(tt.name, func(t *testing.T) {
+			counters := tt.setupCounters()
+			observer := NewCounterObserver(counters)
+
+			for _, event := range tt.events {
+				if tt.expectPanic {
+					assert.NotPanics(t, func() {
+						observer.HandleEvent(event)
+					})
+				} else if tt.shouldPanic {
+					assert.NotPanics(t, func() {
+						observer.HandleEvent(event)
+					})
+				} else {
+					assert.NotPanics(t, func() {
+						observer.HandleEvent(event)
+					})
+				}
 			}
 
-			observer := NewObserver(tt.metricName, tt.metricType, metric)
-
-			s.NotNil(observer)
-			s.Equal(tt.expectedName, observer.name)
-			s.Equal(tt.expectedType, observer.metricType)
+			if tt.verifyMocks {
+				for _, counter := range counters {
+					if mockCounter, ok := counter.(*MockCounter); ok {
+						mockCounter.AssertExpectations(t)
+					}
+				}
+			}
 		})
 	}
 }
 
-// TestObserver_HandleEvent_Counter tests handling counter events
-func (s *ObserverTestSuite) TestObserver_HandleEvent_Counter() {
-	counter := &MockCounter{}
-	counter.On("With", []string{"label1", "value1"}).Return(counter)
-	counter.On("Add", 5.0).Return()
+func TestGaugeObserver(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupGauges func() map[string]kit.Gauge
+		events      []Event
+		shouldPanic bool
+		verifyMocks bool
+	}{
+		{
+			name: "handle multiple gauge events",
+			setupGauges: func() map[string]kit.Gauge {
+				gauge1 := &MockGauge{}
+				gauge1.On("With", []string{"label1", "value1"}).Return(gauge1)
+				gauge1.On("Set", 42.5).Return()
 
-	observer := NewObserver("test_counter", COUNTER, Metric{counter: counter})
+				gauge2 := &MockGauge{}
+				gauge2.On("With", []string{"label2", "value2"}).Return(gauge2)
+				gauge2.On("Set", 100.0).Return()
 
-	event := Event{
-		Name:   "test_counter",
-		Labels: []string{"label1", "value1"},
-		Value:  5.0,
+				return map[string]kit.Gauge{
+					"test_gauge_1": gauge1,
+					"test_gauge_2": gauge2,
+				}
+			},
+			events: []Event{
+				{Name: "test_gauge_1", Labels: []string{"label1", "value1"}, Value: 42.5},
+				{Name: "test_gauge_2", Labels: []string{"label2", "value2"}, Value: 100.0},
+				{Name: "unknown_gauge", Labels: []string{"label3", "value3"}, Value: 200.0},
+			},
+			verifyMocks: true,
+		},
+		{
+			name: "handle nil gauge gracefully",
+			setupGauges: func() map[string]kit.Gauge {
+				return map[string]kit.Gauge{
+					"test_gauge": nil,
+				}
+			},
+			events: []Event{
+				{Name: "test_gauge", Labels: []string{}, Value: 1.0},
+			},
+			shouldPanic: false,
+		},
 	}
 
-	observer.HandleEvent(event)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gauges := tt.setupGauges()
+			observer := NewGaugeObserver(gauges)
 
-	counter.AssertExpectations(s.T())
+			for _, event := range tt.events {
+				if tt.shouldPanic {
+					assert.NotPanics(t, func() {
+						observer.HandleEvent(event)
+					})
+				} else {
+					assert.NotPanics(t, func() {
+						observer.HandleEvent(event)
+					})
+				}
+			}
+
+			if tt.verifyMocks {
+				for _, gauge := range gauges {
+					if mockGauge, ok := gauge.(*MockGauge); ok {
+						mockGauge.AssertExpectations(t)
+					}
+				}
+			}
+		})
+	}
 }
 
-// TestObserver_HandleEvent_Gauge tests handling gauge events
-func (s *ObserverTestSuite) TestObserver_HandleEvent_Gauge() {
-	gauge := &MockGauge{}
-	gauge.On("With", []string{"label1", "value1"}).Return(gauge)
-	gauge.On("Set", 42.5).Return()
+func TestHistogramObserver(t *testing.T) {
+	tests := []struct {
+		name            string
+		setupHistograms func() map[string]kit.Histogram
+		events          []Event
+		shouldPanic     bool
+		verifyMocks     bool
+	}{
+		{
+			name: "handle multiple histogram events",
+			setupHistograms: func() map[string]kit.Histogram {
+				histogram1 := &MockHistogram{}
+				histogram1.On("With", []string{"label1", "value1"}).Return(histogram1)
+				histogram1.On("Observe", 0.125).Return()
 
-	observer := NewObserver("test_gauge", GAUGE, Metric{gauge: gauge})
+				histogram2 := &MockHistogram{}
+				histogram2.On("With", []string{"label2", "value2"}).Return(histogram2)
+				histogram2.On("Observe", 0.250).Return()
 
-	event := Event{
-		Name:   "test_gauge",
-		Labels: []string{"label1", "value1"},
-		Value:  42.5,
+				return map[string]kit.Histogram{
+					"test_histogram_1": histogram1,
+					"test_histogram_2": histogram2,
+				}
+			},
+			events: []Event{
+				{Name: "test_histogram_1", Labels: []string{"label1", "value1"}, Value: 0.125},
+				{Name: "test_histogram_2", Labels: []string{"label2", "value2"}, Value: 0.250},
+				{Name: "unknown_histogram", Labels: []string{"label3", "value3"}, Value: 0.500},
+			},
+			verifyMocks: true,
+		},
+		{
+			name: "handle nil histogram gracefully",
+			setupHistograms: func() map[string]kit.Histogram {
+				return map[string]kit.Histogram{
+					"test_histogram": nil,
+				}
+			},
+			events: []Event{
+				{Name: "test_histogram", Labels: []string{}, Value: 1.0},
+			},
+			shouldPanic: false,
+		},
 	}
 
-	observer.HandleEvent(event)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			histograms := tt.setupHistograms()
+			observer := NewHistogramObserver(histograms)
 
-	gauge.AssertExpectations(s.T())
-}
+			for _, event := range tt.events {
+				if tt.shouldPanic {
+					assert.NotPanics(t, func() {
+						observer.HandleEvent(event)
+					})
+				} else {
+					assert.NotPanics(t, func() {
+						observer.HandleEvent(event)
+					})
+				}
+			}
 
-// TestObserver_HandleEvent_Histogram tests handling histogram events
-func (s *ObserverTestSuite) TestObserver_HandleEvent_Histogram() {
-	histogram := &MockHistogram{}
-	histogram.On("With", []string{"label1", "value1"}).Return(histogram)
-	histogram.On("Observe", 0.125).Return()
-
-	observer := NewObserver("test_histogram", HISTOGRAM, Metric{histogram: histogram})
-
-	event := Event{
-		Name:   "test_histogram",
-		Labels: []string{"label1", "value1"},
-		Value:  0.125,
+			if tt.verifyMocks {
+				for _, histogram := range histograms {
+					if mockHistogram, ok := histogram.(*MockHistogram); ok {
+						mockHistogram.AssertExpectations(t)
+					}
+				}
+			}
+		})
 	}
-
-	observer.HandleEvent(event)
-
-	histogram.AssertExpectations(s.T())
-}
-
-// TestObserver_HandleEvent_WrongName tests that events with wrong names are ignored
-func (s *ObserverTestSuite) TestObserver_HandleEvent_WrongName() {
-	counter := &MockCounter{}
-	// No expectations set - method should not be called
-
-	observer := NewObserver("test_counter", COUNTER, Metric{counter: counter})
-
-	event := Event{
-		Name:   "different_counter",
-		Labels: []string{"label1", "value1"},
-		Value:  5.0,
-	}
-
-	observer.HandleEvent(event)
-
-	// Should not be called because name doesn't match
-	counter.AssertNotCalled(s.T(), "With")
-	counter.AssertNotCalled(s.T(), "Add")
-}
-
-// TestObserver_HandleEvent_NilCounter tests handling events when counter is nil
-func (s *ObserverTestSuite) TestObserver_HandleEvent_NilCounter() {
-	observer := NewObserver("test_counter", COUNTER, Metric{})
-
-	event := Event{
-		Name:   "test_counter",
-		Labels: []string{},
-		Value:  1.0,
-	}
-
-	// Should not panic, just print error
-	s.NotPanics(func() {
-		observer.HandleEvent(event)
-	})
-}
-
-// TestObserver_HandleEvent_NilGauge tests handling events when gauge is nil
-func (s *ObserverTestSuite) TestObserver_HandleEvent_NilGauge() {
-	observer := NewObserver("test_gauge", GAUGE, Metric{})
-
-	event := Event{
-		Name:   "test_gauge",
-		Labels: []string{},
-		Value:  1.0,
-	}
-
-	// Should not panic, just print error
-	s.NotPanics(func() {
-		observer.HandleEvent(event)
-	})
-}
-
-// TestObserver_HandleEvent_NilHistogram tests handling events when histogram is nil
-func (s *ObserverTestSuite) TestObserver_HandleEvent_NilHistogram() {
-	observer := NewObserver("test_histogram", HISTOGRAM, Metric{})
-
-	event := Event{
-		Name:   "test_histogram",
-		Labels: []string{},
-		Value:  1.0,
-	}
-
-	// Should not panic, just print error
-	s.NotPanics(func() {
-		observer.HandleEvent(event)
-	})
-}
-
-// TestObserver_HandleEvent_EmptyLabels tests handling events with empty labels
-func (s *ObserverTestSuite) TestObserver_HandleEvent_EmptyLabels() {
-	counter := &MockCounter{}
-	counter.On("With", []string{}).Return(counter)
-	counter.On("Add", 10.0).Return()
-
-	observer := NewObserver("test_counter", COUNTER, Metric{counter: counter})
-
-	event := Event{
-		Name:   "test_counter",
-		Labels: []string{},
-		Value:  10.0,
-	}
-
-	observer.HandleEvent(event)
-
-	counter.AssertExpectations(s.T())
-}
-
-// TestObserver_HandleEvent_MultipleLabels tests handling events with multiple label pairs
-func (s *ObserverTestSuite) TestObserver_HandleEvent_MultipleLabels() {
-	counter := &MockCounter{}
-	expectedLabels := []string{PartitionLabel, "0", TopicLabel, "test-topic", ErrorTypeLabel, "decode_error"}
-	counter.On("With", expectedLabels).Return(counter)
-	counter.On("Add", 1.0).Return()
-
-	observer := NewObserver(ConsumerFetchErrors, COUNTER, Metric{counter: counter})
-
-	event := Event{
-		Name:   ConsumerFetchErrors,
-		Labels: expectedLabels,
-		Value:  1.0,
-	}
-
-	observer.HandleEvent(event)
-
-	counter.AssertExpectations(s.T())
-}
-
-// TestObserver_HandleEvent_PanicInCounterWith tests panic recovery when counter.With panics
-func (s *ObserverTestSuite) TestObserver_HandleEvent_PanicInCounterWith() {
-	counter := &MockCounter{}
-	// Simulate a panic in With (e.g., label count mismatch in Prometheus)
-	counter.On("With", []string{"label1", "value1"}).Run(func(args mock.Arguments) {
-		panic("label count mismatch: expected 2 labels but got 1")
-	}).Return(counter)
-
-	observer := NewObserver("test_counter", COUNTER, Metric{counter: counter})
-
-	event := Event{
-		Name:   "test_counter",
-		Labels: []string{"label1", "value1"},
-		Value:  5.0,
-	}
-
-	// Should not panic - panic should be caught and logged
-	s.NotPanics(func() {
-		observer.HandleEvent(event)
-	})
-
-	counter.AssertExpectations(s.T())
-}
-
-// TestObserver_HandleEvent_PanicInCounterAdd tests panic recovery when counter.Add panics
-func (s *ObserverTestSuite) TestObserver_HandleEvent_PanicInCounterAdd() {
-	counter := &MockCounter{}
-	counter.On("With", []string{}).Return(counter)
-	// Simulate a panic in Add
-	counter.On("Add", 5.0).Run(func(args mock.Arguments) {
-		panic("invalid counter value")
-	})
-
-	observer := NewObserver("test_counter", COUNTER, Metric{counter: counter})
-
-	event := Event{
-		Name:   "test_counter",
-		Labels: []string{},
-		Value:  5.0,
-	}
-
-	// Should not panic - panic should be caught and logged
-	s.NotPanics(func() {
-		observer.HandleEvent(event)
-	})
-
-	counter.AssertExpectations(s.T())
-}
-
-// TestObserver_HandleEvent_PanicInGaugeWith tests panic recovery when gauge.With panics
-func (s *ObserverTestSuite) TestObserver_HandleEvent_PanicInGaugeWith() {
-	gauge := &MockGauge{}
-	// Simulate a panic in With
-	gauge.On("With", []string{"label1", "value1"}).Run(func(args mock.Arguments) {
-		panic("invalid label value: empty string not allowed")
-	}).Return(gauge)
-
-	observer := NewObserver("test_gauge", GAUGE, Metric{gauge: gauge})
-
-	event := Event{
-		Name:   "test_gauge",
-		Labels: []string{"label1", "value1"},
-		Value:  42.5,
-	}
-
-	// Should not panic - panic should be caught and logged
-	s.NotPanics(func() {
-		observer.HandleEvent(event)
-	})
-
-	gauge.AssertExpectations(s.T())
-}
-
-// TestObserver_HandleEvent_PanicInGaugeSet tests panic recovery when gauge.Set panics
-func (s *ObserverTestSuite) TestObserver_HandleEvent_PanicInGaugeSet() {
-	gauge := &MockGauge{}
-	gauge.On("With", []string{}).Return(gauge)
-	// Simulate a panic in Set
-	gauge.On("Set", 42.5).Run(func(args mock.Arguments) {
-		panic("invalid gauge value: NaN not allowed")
-	})
-
-	observer := NewObserver("test_gauge", GAUGE, Metric{gauge: gauge})
-
-	event := Event{
-		Name:   "test_gauge",
-		Labels: []string{},
-		Value:  42.5,
-	}
-
-	// Should not panic - panic should be caught and logged
-	s.NotPanics(func() {
-		observer.HandleEvent(event)
-	})
-
-	gauge.AssertExpectations(s.T())
-}
-
-// TestObserver_HandleEvent_PanicInHistogramWith tests panic recovery when histogram.With panics
-func (s *ObserverTestSuite) TestObserver_HandleEvent_PanicInHistogramWith() {
-	histogram := &MockHistogram{}
-	// Simulate a panic in With
-	histogram.On("With", []string{"label1", "value1"}).Run(func(args mock.Arguments) {
-		panic("inconsistent cardinality")
-	}).Return(histogram)
-
-	observer := NewObserver("test_histogram", HISTOGRAM, Metric{histogram: histogram})
-
-	event := Event{
-		Name:   "test_histogram",
-		Labels: []string{"label1", "value1"},
-		Value:  0.125,
-	}
-
-	// Should not panic - panic should be caught and logged
-	s.NotPanics(func() {
-		observer.HandleEvent(event)
-	})
-
-	histogram.AssertExpectations(s.T())
-}
-
-// TestObserver_HandleEvent_PanicInHistogramObserve tests panic recovery when histogram.Observe panics
-func (s *ObserverTestSuite) TestObserver_HandleEvent_PanicInHistogramObserve() {
-	histogram := &MockHistogram{}
-	histogram.On("With", []string{}).Return(histogram)
-	// Simulate a panic in Observe
-	histogram.On("Observe", 0.125).Run(func(args mock.Arguments) {
-		panic("invalid histogram value: negative value not allowed")
-	})
-
-	observer := NewObserver("test_histogram", HISTOGRAM, Metric{histogram: histogram})
-
-	event := Event{
-		Name:   "test_histogram",
-		Labels: []string{},
-		Value:  0.125,
-	}
-
-	// Should not panic - panic should be caught and logged
-	s.NotPanics(func() {
-		observer.HandleEvent(event)
-	})
-
-	histogram.AssertExpectations(s.T())
-}
-
-// TestObserver_HandleEvent_MultiplePanics tests that observer continues working after a panic
-func (s *ObserverTestSuite) TestObserver_HandleEvent_MultiplePanics() {
-	counter := &MockCounter{}
-
-	// First call panics
-	counter.On("With", []string{"label1", "value1"}).Run(func(args mock.Arguments) {
-		panic("first panic")
-	}).Return(counter).Once()
-
-	// Second call succeeds
-	counter.On("With", []string{"label2", "value2"}).Return(counter).Once()
-	counter.On("Add", 10.0).Return().Once()
-
-	observer := NewObserver("test_counter", COUNTER, Metric{counter: counter})
-
-	event1 := Event{
-		Name:   "test_counter",
-		Labels: []string{"label1", "value1"},
-		Value:  5.0,
-	}
-
-	event2 := Event{
-		Name:   "test_counter",
-		Labels: []string{"label2", "value2"},
-		Value:  10.0,
-	}
-
-	// First event should panic and recover
-	s.NotPanics(func() {
-		observer.HandleEvent(event1)
-	})
-
-	// Observer should still work after panic
-	s.NotPanics(func() {
-		observer.HandleEvent(event2)
-	})
-
-	counter.AssertExpectations(s.T())
 }

--- a/internal/metrics/observer_test.go
+++ b/internal/metrics/observer_test.go
@@ -262,3 +262,208 @@ func TestHistogramObserver(t *testing.T) {
 		})
 	}
 }
+
+// TestSubjectUnknownMetrics tests the flag-based unknown metrics tracking in subject
+func TestSubjectUnknownMetrics(t *testing.T) {
+	tests := []struct {
+		name          string
+		events        []Event
+		expectedCalls []struct{ metricName, metricType string }
+	}{
+		{
+			name: "tracks unknown metrics not in any observer",
+			events: []Event{
+				{Name: "completely_unknown", Labels: []string{}, Value: 1.0},
+				{Name: "another_unknown", Labels: []string{}, Value: 2.0},
+			},
+			expectedCalls: []struct{ metricName, metricType string }{
+				{"completely_unknown", "unknown"},
+				{"another_unknown", "unknown"},
+			},
+		},
+		{
+			name: "does not track metrics that exist in counter observer",
+			events: []Event{
+				{Name: "fetch_errors", Labels: []string{}, Value: 1.0},
+				{Name: "completely_unknown", Labels: []string{}, Value: 1.0},
+			},
+			expectedCalls: []struct{ metricName, metricType string }{
+				{"completely_unknown", "unknown"},
+			},
+		},
+		{
+			name: "does not track metrics that exist in gauge observer",
+			events: []Event{
+				{Name: "fetch_pauses", Labels: []string{}, Value: 1.0},
+				{Name: "completely_unknown", Labels: []string{}, Value: 1.0},
+			},
+			expectedCalls: []struct{ metricName, metricType string }{
+				{"completely_unknown", "unknown"},
+			},
+		},
+		{
+			name: "does not track metrics that exist in histogram observer",
+			events: []Event{
+				{Name: "kafka_publish_latency_seconds", Labels: []string{}, Value: 1.0},
+				{Name: "completely_unknown", Labels: []string{}, Value: 1.0},
+			},
+			expectedCalls: []struct{ metricName, metricType string }{
+				{"completely_unknown", "unknown"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			unknownCounter := &MockCounter{}
+
+			// Set up expectations for unknown metric calls
+			for _, call := range tt.expectedCalls {
+				unknownCounter.On("With",
+					[]string{"metric_name", call.metricName, "metric_type", call.metricType}).Return(unknownCounter)
+				unknownCounter.On("Add", 1.0).Return()
+			}
+
+			// Create mocks for known metrics that might be called
+			fetchErrorsCounter := &MockCounter{}
+			fetchPausesGauge := &MockGauge{}
+			kafkaLatencyHistogram := &MockHistogram{}
+
+			// Set up expectations for known metrics that will be called in tests
+			for _, event := range tt.events {
+				switch event.Name {
+				case "fetch_errors":
+					fetchErrorsCounter.On("With", event.Labels).Return(fetchErrorsCounter)
+					fetchErrorsCounter.On("Add", event.Value).Return()
+				case "fetch_pauses":
+					fetchPausesGauge.On("With", event.Labels).Return(fetchPausesGauge)
+					fetchPausesGauge.On("Set", event.Value).Return()
+				case "kafka_publish_latency_seconds":
+					kafkaLatencyHistogram.On("With", event.Labels).Return(kafkaLatencyHistogram)
+					kafkaLatencyHistogram.On("Observe", event.Value).Return()
+				}
+			}
+
+			// Create a metrics struct with real metric maps
+			mockMetrics := Metrics{
+				ConsumerFetchErrors:    fetchErrorsCounter,
+				ConsumerCommitErrors:   &MockCounter{},
+				ConsumerPauses:         fetchPausesGauge,
+				BucketKeyErrorCount:    &MockCounter{},
+				PublisherOutcomes:      &MockCounter{},
+				PublisherErrorsCounter: &MockCounter{},
+				KafkaPublished:         &MockCounter{},
+				KafkaPublishLatency:    kafkaLatencyHistogram,
+				Panics:                 &MockCounter{},
+				UnknownMetrics:         unknownCounter,
+			}
+
+			subject := New(mockMetrics)
+
+			// Send events synchronously
+			for _, event := range tt.events {
+				subject.NotifySync(event)
+			}
+
+			unknownCounter.AssertExpectations(t)
+			fetchErrorsCounter.AssertExpectations(t)
+			fetchPausesGauge.AssertExpectations(t)
+			kafkaLatencyHistogram.AssertExpectations(t)
+		})
+	}
+}
+
+func TestSubjectUnknownMetricsNil(t *testing.T) {
+	// Test that nil unknown metrics counter doesn't cause panics
+	mockMetrics := Metrics{
+		ConsumerFetchErrors:    &MockCounter{},
+		ConsumerCommitErrors:   &MockCounter{},
+		ConsumerPauses:         &MockGauge{},
+		BucketKeyErrorCount:    &MockCounter{},
+		PublisherOutcomes:      &MockCounter{},
+		PublisherErrorsCounter: &MockCounter{},
+		KafkaPublished:         &MockCounter{},
+		KafkaPublishLatency:    &MockHistogram{},
+		Panics:                 &MockCounter{},
+		UnknownMetrics:         nil, // nil unknown counter
+	}
+	subject := New(mockMetrics)
+
+	assert.NotPanics(t, func() {
+		subject.NotifySync(Event{Name: "unknown", Labels: []string{}, Value: 1.0})
+	})
+}
+
+func TestObserverReturnValues(t *testing.T) {
+	t.Run("counter observer returns true when metric exists", func(t *testing.T) {
+		counter := &MockCounter{}
+		counter.On("With", []string{"label1", "value1"}).Return(counter)
+		counter.On("Add", 5.0).Return()
+
+		counters := map[string]kit.Counter{
+			"test_counter": counter,
+		}
+		observer := NewCounterObserver(counters)
+
+		handled := observer.HandleEvent(Event{
+			Name:   "test_counter",
+			Labels: []string{"label1", "value1"},
+			Value:  5.0,
+		})
+
+		assert.True(t, handled)
+		counter.AssertExpectations(t)
+	})
+
+	t.Run("counter observer returns false when metric does not exist", func(t *testing.T) {
+		observer := NewCounterObserver(map[string]kit.Counter{})
+
+		handled := observer.HandleEvent(Event{
+			Name:   "unknown_counter",
+			Labels: []string{},
+			Value:  1.0,
+		})
+
+		assert.False(t, handled)
+	})
+
+	t.Run("gauge observer returns true when metric exists", func(t *testing.T) {
+		gauge := &MockGauge{}
+		gauge.On("With", []string{}).Return(gauge)
+		gauge.On("Set", 42.0).Return()
+
+		gauges := map[string]kit.Gauge{
+			"test_gauge": gauge,
+		}
+		observer := NewGaugeObserver(gauges)
+
+		handled := observer.HandleEvent(Event{
+			Name:   "test_gauge",
+			Labels: []string{},
+			Value:  42.0,
+		})
+
+		assert.True(t, handled)
+		gauge.AssertExpectations(t)
+	})
+
+	t.Run("histogram observer returns true when metric exists", func(t *testing.T) {
+		histogram := &MockHistogram{}
+		histogram.On("With", []string{}).Return(histogram)
+		histogram.On("Observe", 0.123).Return()
+
+		histograms := map[string]kit.Histogram{
+			"test_histogram": histogram,
+		}
+		observer := NewHistogramObserver(histograms)
+
+		handled := observer.HandleEvent(Event{
+			Name:   "test_histogram",
+			Labels: []string{},
+			Value:  0.123,
+		})
+
+		assert.True(t, handled)
+		histogram.AssertExpectations(t)
+	})
+}

--- a/internal/metrics/observer_test.go
+++ b/internal/metrics/observer_test.go
@@ -88,7 +88,7 @@ func TestCounterObserver(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			counters := tt.setupCounters()
-			observer := NewCounterObserver(counters)
+			observer := NewCounterObserver(counters, nil)
 
 			for _, event := range tt.events {
 				if tt.expectPanic {
@@ -165,7 +165,7 @@ func TestGaugeObserver(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gauges := tt.setupGauges()
-			observer := NewGaugeObserver(gauges)
+			observer := NewGaugeObserver(gauges, nil)
 
 			for _, event := range tt.events {
 				if tt.shouldPanic {
@@ -238,7 +238,7 @@ func TestHistogramObserver(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			histograms := tt.setupHistograms()
-			observer := NewHistogramObserver(histograms)
+			observer := NewHistogramObserver(histograms, nil)
 
 			for _, event := range tt.events {
 				if tt.shouldPanic {
@@ -356,6 +356,7 @@ func TestSubjectUnknownMetrics(t *testing.T) {
 				KafkaPublishLatency:    kafkaLatencyHistogram,
 				Panics:                 &MockCounter{},
 				UnknownMetrics:         unknownCounter,
+				MetricPanics:           &MockCounter{},
 			}
 
 			subject := New(mockMetrics)
@@ -386,6 +387,7 @@ func TestSubjectUnknownMetricsNil(t *testing.T) {
 		KafkaPublishLatency:    &MockHistogram{},
 		Panics:                 &MockCounter{},
 		UnknownMetrics:         nil, // nil unknown counter
+		MetricPanics:           &MockCounter{},
 	}
 	subject := New(mockMetrics)
 
@@ -403,7 +405,7 @@ func TestObserverReturnValues(t *testing.T) {
 		counters := map[string]kit.Counter{
 			"test_counter": counter,
 		}
-		observer := NewCounterObserver(counters)
+		observer := NewCounterObserver(counters, nil)
 
 		handled := observer.HandleEvent(Event{
 			Name:   "test_counter",
@@ -416,7 +418,7 @@ func TestObserverReturnValues(t *testing.T) {
 	})
 
 	t.Run("counter observer returns false when metric does not exist", func(t *testing.T) {
-		observer := NewCounterObserver(map[string]kit.Counter{})
+		observer := NewCounterObserver(map[string]kit.Counter{}, nil)
 
 		handled := observer.HandleEvent(Event{
 			Name:   "unknown_counter",
@@ -435,7 +437,7 @@ func TestObserverReturnValues(t *testing.T) {
 		gauges := map[string]kit.Gauge{
 			"test_gauge": gauge,
 		}
-		observer := NewGaugeObserver(gauges)
+		observer := NewGaugeObserver(gauges, nil)
 
 		handled := observer.HandleEvent(Event{
 			Name:   "test_gauge",
@@ -455,7 +457,7 @@ func TestObserverReturnValues(t *testing.T) {
 		histograms := map[string]kit.Histogram{
 			"test_histogram": histogram,
 		}
-		observer := NewHistogramObserver(histograms)
+		observer := NewHistogramObserver(histograms, nil)
 
 		handled := observer.HandleEvent(Event{
 			Name:   "test_histogram",
@@ -465,5 +467,112 @@ func TestObserverReturnValues(t *testing.T) {
 
 		assert.True(t, handled)
 		histogram.AssertExpectations(t)
+	})
+}
+
+func TestObserverPanicTracking(t *testing.T) {
+	t.Run("counter observer tracks panics", func(t *testing.T) {
+		panicCounter := &MockCounter{}
+		panicCounter.On("With", []string{"metric_name", "test_counter", "metric_type", "counter"}).Return(panicCounter)
+		panicCounter.On("Add", 1.0).Return()
+
+		counter := &MockCounter{}
+		counter.On("With", []string{"label1", "value1"}).Return(counter)
+		counter.On("Add", 5.0).Run(func(args mock.Arguments) {
+			panic("test panic")
+		})
+
+		counters := map[string]kit.Counter{
+			"test_counter": counter,
+		}
+		observer := NewCounterObserver(counters, panicCounter)
+
+		handled := observer.HandleEvent(Event{
+			Name:   "test_counter",
+			Labels: []string{"label1", "value1"},
+			Value:  5.0,
+		})
+
+		assert.False(t, handled) // Should return false when panic occurs
+		counter.AssertExpectations(t)
+		panicCounter.AssertExpectations(t)
+	})
+
+	t.Run("gauge observer tracks panics", func(t *testing.T) {
+		panicCounter := &MockCounter{}
+		panicCounter.On("With", []string{"metric_name", "test_gauge", "metric_type", "gauge"}).Return(panicCounter)
+		panicCounter.On("Add", 1.0).Return()
+
+		gauge := &MockGauge{}
+		gauge.On("With", []string{}).Return(gauge)
+		gauge.On("Set", 42.0).Run(func(args mock.Arguments) {
+			panic("test panic")
+		})
+
+		gauges := map[string]kit.Gauge{
+			"test_gauge": gauge,
+		}
+		observer := NewGaugeObserver(gauges, panicCounter)
+
+		handled := observer.HandleEvent(Event{
+			Name:   "test_gauge",
+			Labels: []string{},
+			Value:  42.0,
+		})
+
+		assert.False(t, handled)
+		gauge.AssertExpectations(t)
+		panicCounter.AssertExpectations(t)
+	})
+
+	t.Run("histogram observer tracks panics", func(t *testing.T) {
+		panicCounter := &MockCounter{}
+		panicCounter.On("With", []string{"metric_name", "test_histogram", "metric_type", "histogram"}).Return(panicCounter)
+		panicCounter.On("Add", 1.0).Return()
+
+		histogram := &MockHistogram{}
+		histogram.On("With", []string{}).Return(histogram)
+		histogram.On("Observe", 0.123).Run(func(args mock.Arguments) {
+			panic("test panic")
+		})
+
+		histograms := map[string]kit.Histogram{
+			"test_histogram": histogram,
+		}
+		observer := NewHistogramObserver(histograms, panicCounter)
+
+		handled := observer.HandleEvent(Event{
+			Name:   "test_histogram",
+			Labels: []string{},
+			Value:  0.123,
+		})
+
+		assert.False(t, handled)
+		histogram.AssertExpectations(t)
+		panicCounter.AssertExpectations(t)
+	})
+
+	t.Run("nil panic counter doesn't cause issues", func(t *testing.T) {
+		counter := &MockCounter{}
+		counter.On("With", []string{}).Return(counter)
+		counter.On("Add", 5.0).Run(func(args mock.Arguments) {
+			panic("test panic")
+		})
+
+		counters := map[string]kit.Counter{
+			"test_counter": counter,
+		}
+		observer := NewCounterObserver(counters, nil) // nil panic counter
+
+		assert.NotPanics(t, func() {
+			handled := observer.HandleEvent(Event{
+				Name:   "test_counter",
+				Labels: []string{},
+				Value:  5.0,
+			})
+			assert.False(t, handled) // Should return false when panic occurs
+		})
+
+		counter.AssertExpectations(t)
 	})
 }

--- a/internal/metrics/subject.go
+++ b/internal/metrics/subject.go
@@ -30,32 +30,40 @@ type Metric struct {
 	histogram kit.Histogram
 }
 
-// New creates a new Subject for metric events
+// New creates a new Subject for metric events with the 3 standard observers
 func New(m Metrics) *observe.Subject[Event] {
 	subject := observe.NewSubject[Event]()
 
-	observers := createObservers(m)
-
-	for _, observer := range observers {
-		subject.Attach(observer.HandleEvent)
+	// Create counter observer with all counters
+	counterMetrics := map[string]kit.Counter{
+		"fetch_errors":                   m.ConsumerFetchErrors,
+		"commit_errors":                  m.ConsumerCommitErrors,
+		"bucket_key_error_count":         m.BucketKeyErrorCount,
+		"publish_outcomes":               m.PublisherOutcomes,
+		"publish_errors_total":           m.PublisherErrorsCounter,
+		"kafka_messages_published_total": m.KafkaPublished,
+		"panics_total":                   m.Panics,
 	}
+
+	// Create gauge observer with all gauges
+	gaugeMetrics := map[string]kit.Gauge{
+		"fetch_pauses": m.ConsumerPauses,
+	}
+
+	// Create histogram observer with all histograms
+	histogramMetrics := map[string]kit.Histogram{
+		"kafka_publish_latency_seconds": m.KafkaPublishLatency,
+	}
+
+	counterObserver := NewCounterObserver(counterMetrics)
+	gaugeObserver := NewGaugeObserver(gaugeMetrics)
+	histogramObserver := NewHistogramObserver(histogramMetrics)
+
+	subject.Attach(counterObserver.HandleEvent)
+	subject.Attach(gaugeObserver.HandleEvent)
+	subject.Attach(histogramObserver.HandleEvent)
 
 	return subject
-}
-
-func createObservers(m Metrics) []*Observer {
-	observers := []*Observer{
-		NewObserver(ConsumerFetchErrors, COUNTER, Metric{counter: m.ConsumerFetchErrors}),
-		NewObserver(ConsumerCommitErrors, COUNTER, Metric{counter: m.ConsumerCommitErrors}),
-		NewObserver(ConsumerPauses, GAUGE, Metric{gauge: m.ConsumerPauses}),
-		NewObserver(BucketKeyErrorCount, COUNTER, Metric{counter: m.BucketKeyErrorCount}),
-		NewObserver(PublisherOutcomes, COUNTER, Metric{counter: m.PublisherOutcomes}),
-		NewObserver(PublisherErrorsCounter, COUNTER, Metric{counter: m.PublisherErrorsCounter}),
-		NewObserver(KafkaPublished, COUNTER, Metric{counter: m.KafkaPublished}),
-		NewObserver(KafkaPublishLatency, HISTOGRAM, Metric{histogram: m.KafkaPublishLatency}),
-		NewObserver(Panics, COUNTER, Metric{counter: m.Panics}),
-	}
-	return observers
 }
 
 func NewNoop() *observe.Subject[Event] {

--- a/internal/metrics/subject.go
+++ b/internal/metrics/subject.go
@@ -37,22 +37,21 @@ func New(m Metrics) *observe.Subject[Event] {
 
 	// Create observers
 	counterMetrics := map[string]kit.Counter{
-		"fetch_errors":                   m.ConsumerFetchErrors,
-		"commit_errors":                  m.ConsumerCommitErrors,
-		"bucket_key_error_count":         m.BucketKeyErrorCount,
-		"publish_outcomes":               m.PublisherOutcomes,
-		"publish_errors_total":           m.PublisherErrorsCounter,
-		"kafka_messages_published_total": m.KafkaPublished,
-		"panics_total":                   m.Panics,
-		"unknown_metrics_total":          m.UnknownMetrics,
+		ConsumerFetchErrors:    m.ConsumerFetchErrors,
+		ConsumerCommitErrors:   m.ConsumerCommitErrors,
+		BucketKeyErrorCount:    m.BucketKeyErrorCount,
+		PublisherOutcomes:      m.PublisherOutcomes,
+		PublisherErrorsCounter: m.PublisherErrorsCounter,
+		KafkaPublished:         m.KafkaPublished,
+		Panics:                 m.Panics,
 	}
 
 	gaugeMetrics := map[string]kit.Gauge{
-		"fetch_pauses": m.ConsumerPauses,
+		ConsumerPauses: m.ConsumerPauses,
 	}
 
 	histogramMetrics := map[string]kit.Histogram{
-		"kafka_publish_latency_seconds": m.KafkaPublishLatency,
+		KafkaPublishLatency: m.KafkaPublishLatency,
 	}
 
 	counterObserver := NewCounterObserver(counterMetrics)

--- a/internal/metrics/subject.go
+++ b/internal/metrics/subject.go
@@ -22,6 +22,7 @@ type Metrics struct {
 	KafkaPublished      kit.Counter
 	KafkaPublishLatency kit.Histogram
 	Panics              kit.Counter
+	UnknownMetrics      kit.Counter
 }
 
 type Metric struct {
@@ -30,11 +31,11 @@ type Metric struct {
 	histogram kit.Histogram
 }
 
-// New creates a new Subject for metric events with the 3 standard observers
+// New creates a new Subject for metric events with unknown metrics tracking
 func New(m Metrics) *observe.Subject[Event] {
 	subject := observe.NewSubject[Event]()
 
-	// Create counter observer with all counters
+	// Create observers
 	counterMetrics := map[string]kit.Counter{
 		"fetch_errors":                   m.ConsumerFetchErrors,
 		"commit_errors":                  m.ConsumerCommitErrors,
@@ -43,14 +44,13 @@ func New(m Metrics) *observe.Subject[Event] {
 		"publish_errors_total":           m.PublisherErrorsCounter,
 		"kafka_messages_published_total": m.KafkaPublished,
 		"panics_total":                   m.Panics,
+		"unknown_metrics_total":          m.UnknownMetrics,
 	}
 
-	// Create gauge observer with all gauges
 	gaugeMetrics := map[string]kit.Gauge{
 		"fetch_pauses": m.ConsumerPauses,
 	}
 
-	// Create histogram observer with all histograms
 	histogramMetrics := map[string]kit.Histogram{
 		"kafka_publish_latency_seconds": m.KafkaPublishLatency,
 	}
@@ -59,9 +59,20 @@ func New(m Metrics) *observe.Subject[Event] {
 	gaugeObserver := NewGaugeObserver(gaugeMetrics)
 	histogramObserver := NewHistogramObserver(histogramMetrics)
 
-	subject.Attach(counterObserver.HandleEvent)
-	subject.Attach(gaugeObserver.HandleEvent)
-	subject.Attach(histogramObserver.HandleEvent)
+	// Create a handler that calls all observers and tracks unknown metrics
+	handleEvent := func(event Event) {
+		// Call all observers and collect their results
+		counterHandled := counterObserver.HandleEvent(event)
+		gaugeHandled := gaugeObserver.HandleEvent(event)
+		histogramHandled := histogramObserver.HandleEvent(event)
+
+		// If no observer handled the event, it's unknown
+		if !counterHandled && !gaugeHandled && !histogramHandled && m.UnknownMetrics != nil {
+			m.UnknownMetrics.With("metric_name", event.Name, "metric_type", "unknown").Add(1)
+		}
+	}
+
+	subject.Attach(handleEvent)
 
 	return subject
 }

--- a/internal/metrics/subject.go
+++ b/internal/metrics/subject.go
@@ -68,7 +68,7 @@ func New(m Metrics) *observe.Subject[Event] {
 
 		// If no observer handled the event, it's unknown
 		if !counterHandled && !gaugeHandled && !histogramHandled && m.UnknownMetrics != nil {
-			m.UnknownMetrics.With("metric_name", event.Name, "metric_type", "unknown").Add(1)
+			m.UnknownMetrics.With(MetricNameLabel, event.Name, MetricTypeLabel, "unknown").Add(1)
 		}
 	}
 

--- a/internal/metrics/subject.go
+++ b/internal/metrics/subject.go
@@ -23,6 +23,7 @@ type Metrics struct {
 	KafkaPublishLatency kit.Histogram
 	Panics              kit.Counter
 	UnknownMetrics      kit.Counter
+	MetricPanics        kit.Counter
 }
 
 type Metric struct {
@@ -54,9 +55,9 @@ func New(m Metrics) *observe.Subject[Event] {
 		KafkaPublishLatency: m.KafkaPublishLatency,
 	}
 
-	counterObserver := NewCounterObserver(counterMetrics)
-	gaugeObserver := NewGaugeObserver(gaugeMetrics)
-	histogramObserver := NewHistogramObserver(histogramMetrics)
+	counterObserver := NewCounterObserver(counterMetrics, m.MetricPanics)
+	gaugeObserver := NewGaugeObserver(gaugeMetrics, m.MetricPanics)
+	histogramObserver := NewHistogramObserver(histogramMetrics, m.MetricPanics)
 
 	// Create a handler that calls all observers and tracks unknown metrics
 	handleEvent := func(event Event) {

--- a/internal/metrics/subject_test.go
+++ b/internal/metrics/subject_test.go
@@ -6,124 +6,299 @@ package metrics
 import (
 	"testing"
 
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/assert"
 )
 
-type SubjectTestSuite struct {
-	suite.Suite
+// createMinimalMetrics creates a Metrics struct with mock metrics
+func createMinimalMetrics() Metrics {
+	return Metrics{
+		ConsumerFetchErrors:    &MockCounter{},
+		ConsumerCommitErrors:   &MockCounter{},
+		ConsumerPauses:         &MockGauge{},
+		BucketKeyErrorCount:    &MockCounter{},
+		PublisherOutcomes:      &MockCounter{},
+		PublisherErrorsCounter: &MockCounter{},
+		KafkaPublished:         &MockCounter{},
+		KafkaPublishLatency:    &MockHistogram{},
+		Panics:                 &MockCounter{},
+	}
 }
 
-func TestSubjectTestSuite(t *testing.T) {
-	suite.Run(t, new(SubjectTestSuite))
-}
-
-// TestNew tests creating a new metrics subject with observers
-func (s *SubjectTestSuite) TestNew() {
-	counter := &MockCounter{}
-	metrics := Metrics{
-		ConsumerFetchErrors: counter,
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name                string
+		setupMetrics        func() Metrics
+		expectNonNilSubject bool
+	}{
+		{
+			name:                "create new subject with minimal metrics",
+			setupMetrics:        createMinimalMetrics,
+			expectNonNilSubject: true,
+		},
 	}
 
-	subject := New(metrics)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockMetrics := tt.setupMetrics()
+			subject := New(mockMetrics)
 
-	s.NotNil(subject)
-}
-
-// TestNew_NotifyObservers tests that observers are notified when events are published
-func (s *SubjectTestSuite) TestNew_NotifyObservers() {
-	counter := &MockCounter{}
-	expectedLabels := []string{PartitionLabel, "0", TopicLabel, "test-topic"}
-	counter.On("With", expectedLabels).Return(counter)
-	counter.On("Add", 1.0).Return()
-
-	metrics := Metrics{
-		ConsumerFetchErrors: counter,
-	}
-
-	subject := New(metrics)
-
-	// Publish an event
-	event := Event{
-		Name:   ConsumerFetchErrors,
-		Labels: expectedLabels,
-		Value:  1.0,
-	}
-
-	subject.NotifySync(event)
-
-	// Verify the counter was called
-	counter.AssertExpectations(s.T())
-}
-
-// TestNew_EventWithDifferentName tests that events with non-matching names are ignored
-func (s *SubjectTestSuite) TestNew_EventWithDifferentName() {
-	counter := &MockCounter{}
-	// No expectations set - methods should not be called
-
-	metrics := Metrics{
-		ConsumerFetchErrors: counter,
-	}
-
-	subject := New(metrics)
-
-	// Publish event with different name
-	event := Event{
-		Name:   "unknown_metric",
-		Labels: []string{},
-		Value:  10.0,
-	}
-
-	subject.Notify(event)
-
-	// Counter should not be called because name doesn't match
-	counter.AssertNotCalled(s.T(), "With")
-	counter.AssertNotCalled(s.T(), "Add")
-}
-
-// TestNewNoop tests creating a no-op metrics subject
-func (s *SubjectTestSuite) TestNewNoop() {
-	subject := NewNoop()
-
-	s.NotNil(subject)
-
-	// Should not panic when notifying
-	event := Event{
-		Name:   "any_metric",
-		Labels: []string{},
-		Value:  42.0,
-	}
-
-	s.NotPanics(func() {
-		subject.Notify(event)
-	})
-}
-
-// TestNewNoop_MultipleEvents tests that noop subject handles multiple events
-func (s *SubjectTestSuite) TestNewNoop_MultipleEvents() {
-	subject := NewNoop()
-
-	s.NotPanics(func() {
-		for i := 0; i < 100; i++ {
-			event := Event{
-				Name:   "test_metric",
-				Labels: []string{"iteration", string(rune(i))},
-				Value:  float64(i),
+			if tt.expectNonNilSubject {
+				assert.NotNil(t, subject)
+			} else {
+				assert.Nil(t, subject)
 			}
-			subject.Notify(event)
-		}
-	})
+		})
+	}
 }
 
-// TestCreateObservers tests the createObservers function
-func (s *SubjectTestSuite) TestCreateObservers() {
-	counter := &MockCounter{}
-	metrics := Metrics{
-		ConsumerFetchErrors: counter,
+func TestSubjectNotify(t *testing.T) {
+	tests := []struct {
+		name         string
+		setupMetrics func() (Metrics, []string)
+		event        Event
+		useSync      bool
+		shouldPanic  bool
+		verifyMocks  bool
+	}{
+		{
+			name: "counter metric handled correctly",
+			setupMetrics: func() (Metrics, []string) {
+				counter := &MockCounter{}
+				expectedLabels := []string{PartitionLabel, "0", TopicLabel, "test-topic"}
+				counter.On("With", expectedLabels).Return(counter)
+				counter.On("Add", 1.0).Return()
+
+				mockMetrics := createMinimalMetrics()
+				mockMetrics.ConsumerFetchErrors = counter
+				return mockMetrics, expectedLabels
+			},
+			event: Event{
+				Name:   "fetch_errors",
+				Labels: []string{PartitionLabel, "0", TopicLabel, "test-topic"},
+				Value:  1.0,
+			},
+			useSync:     true,
+			verifyMocks: true,
+		},
+		{
+			name: "gauge metric handled correctly",
+			setupMetrics: func() (Metrics, []string) {
+				gauge := &MockGauge{}
+				expectedLabels := []string{GroupLabel, "test-group"}
+				gauge.On("With", expectedLabels).Return(gauge)
+				gauge.On("Set", 5.0).Return()
+
+				mockMetrics := createMinimalMetrics()
+				mockMetrics.ConsumerPauses = gauge
+				return mockMetrics, expectedLabels
+			},
+			event: Event{
+				Name:   "fetch_pauses",
+				Labels: []string{GroupLabel, "test-group"},
+				Value:  5.0,
+			},
+			useSync:     true,
+			verifyMocks: true,
+		},
+		{
+			name: "histogram metric handled correctly",
+			setupMetrics: func() (Metrics, []string) {
+				histogram := &MockHistogram{}
+				expectedLabels := []string{OutcomeLabel, "success"}
+				histogram.On("With", expectedLabels).Return(histogram)
+				histogram.On("Observe", 123.45).Return()
+
+				mockMetrics := createMinimalMetrics()
+				mockMetrics.KafkaPublishLatency = histogram
+				return mockMetrics, expectedLabels
+			},
+			event: Event{
+				Name:   "kafka_publish_latency_seconds",
+				Labels: []string{OutcomeLabel, "success"},
+				Value:  123.45,
+			},
+			useSync:     true,
+			verifyMocks: true,
+		},
+		{
+			name: "unknown metric name ignored",
+			setupMetrics: func() (Metrics, []string) {
+				counter := &MockCounter{}
+				// No expectations set - methods should not be called
+
+				mockMetrics := createMinimalMetrics()
+				mockMetrics.ConsumerFetchErrors = counter
+				return mockMetrics, []string{}
+			},
+			event: Event{
+				Name:   "unknown_metric_name",
+				Labels: []string{},
+				Value:  10.0,
+			},
+			useSync:     false,
+			verifyMocks: false, // No mock calls expected
+		},
 	}
 
-	observers := createObservers(metrics)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockMetrics, _ := tt.setupMetrics()
+			subject := New(mockMetrics)
 
-	s.NotNil(observers)
+			if tt.shouldPanic {
+				assert.Panics(t, func() {
+					if tt.useSync {
+						subject.NotifySync(tt.event)
+					} else {
+						subject.Notify(tt.event)
+					}
+				})
+			} else {
+				assert.NotPanics(t, func() {
+					if tt.useSync {
+						subject.NotifySync(tt.event)
+					} else {
+						subject.Notify(tt.event)
+					}
+				})
+			}
 
-	s.Len(observers, 9)
+			if tt.verifyMocks {
+				// Verify specific mocks based on the test
+				switch tt.event.Name {
+				case "fetch_errors":
+					if counter, ok := mockMetrics.ConsumerFetchErrors.(*MockCounter); ok {
+						counter.AssertExpectations(t)
+					}
+				case "fetch_pauses":
+					if gauge, ok := mockMetrics.ConsumerPauses.(*MockGauge); ok {
+						gauge.AssertExpectations(t)
+					}
+				case "kafka_publish_latency_seconds":
+					if histogram, ok := mockMetrics.KafkaPublishLatency.(*MockHistogram); ok {
+						histogram.AssertExpectations(t)
+					}
+				}
+			} else if tt.event.Name == "unknown_metric_name" {
+				// Verify counter was never called for unknown metrics
+				if counter, ok := mockMetrics.ConsumerFetchErrors.(*MockCounter); ok {
+					counter.AssertNotCalled(t, "With")
+					counter.AssertNotCalled(t, "Add")
+				}
+			}
+		})
+	}
+}
+
+func TestSubjectAsync(t *testing.T) {
+	tests := []struct {
+		name         string
+		setupMetrics func() Metrics
+		eventCount   int
+		shouldPanic  bool
+	}{
+		{
+			name:         "async events don't panic",
+			setupMetrics: createMinimalMetrics,
+			eventCount:   10,
+			shouldPanic:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockMetrics := tt.setupMetrics()
+			subject := New(mockMetrics)
+
+			if tt.shouldPanic {
+				assert.Panics(t, func() {
+					for i := 0; i < tt.eventCount; i++ {
+						go subject.Notify(Event{
+							Name:   "publish_outcomes",
+							Labels: []string{"test", "async"},
+							Value:  float64(i),
+						})
+					}
+				})
+			} else {
+				assert.NotPanics(t, func() {
+					for i := 0; i < tt.eventCount; i++ {
+						go subject.Notify(Event{
+							Name:   "publish_outcomes",
+							Labels: []string{"test", "async"},
+							Value:  float64(i),
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestNewNoop(t *testing.T) {
+	tests := []struct {
+		name             string
+		testEvents       []Event
+		eventCount       int // For high volume tests
+		shouldPanic      bool
+		expectNonNilNoop bool
+		testHighVolume   bool
+	}{
+		{
+			name: "noop subject creation",
+			testEvents: []Event{
+				{Name: "any_metric", Labels: []string{}, Value: 42.0},
+				{Name: "another_metric", Labels: []string{"key", "value"}, Value: 100.0},
+			},
+			shouldPanic:      false,
+			expectNonNilNoop: true,
+		},
+		{
+			name:           "noop high volume handling",
+			eventCount:     1000,
+			shouldPanic:    false,
+			testHighVolume: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subject := NewNoop()
+
+			if tt.expectNonNilNoop {
+				assert.NotNil(t, subject)
+			}
+
+			if tt.testHighVolume {
+				assert.NotPanics(t, func() {
+					for i := 0; i < tt.eventCount; i++ {
+						event := Event{
+							Name:   "high_volume_metric",
+							Labels: []string{"iteration", string(rune(i % 10))},
+							Value:  float64(i),
+						}
+						subject.Notify(event)
+					}
+				})
+			} else {
+				for _, event := range tt.testEvents {
+					if tt.shouldPanic {
+						assert.Panics(t, func() {
+							subject.Notify(event)
+						})
+						assert.Panics(t, func() {
+							subject.NotifySync(event)
+						})
+					} else {
+						assert.NotPanics(t, func() {
+							subject.Notify(event)
+						})
+						assert.NotPanics(t, func() {
+							subject.NotifySync(event)
+						})
+					}
+				}
+			}
+		})
+	}
 }

--- a/internal/metrics/subject_test.go
+++ b/internal/metrics/subject_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 // createMinimalMetrics creates a Metrics struct with mock metrics
@@ -203,10 +204,25 @@ func TestSubjectAsync(t *testing.T) {
 		shouldPanic  bool
 	}{
 		{
-			name:         "async events don't panic",
-			setupMetrics: createMinimalMetrics,
-			eventCount:   10,
-			shouldPanic:  false,
+			name: "async events don't panic",
+			setupMetrics: func() Metrics {
+				// Set up mock with expectations for async test
+				publisherOutcomes := &MockCounter{}
+				publisherOutcomes.On("With", []string{"test", "async"}).Return(publisherOutcomes).Maybe()
+				publisherOutcomes.On("Add", mock.AnythingOfType("float64")).Return().Maybe()
+
+				// Set up panic counter expectations
+				panicCounter := &MockCounter{}
+				panicCounter.On("With", []string{"metric_name", "publish_outcomes", "metric_type", "counter"}).Return(panicCounter).Maybe()
+				panicCounter.On("Add", 1.0).Return().Maybe()
+
+				mockMetrics := createMinimalMetrics()
+				mockMetrics.PublisherOutcomes = publisherOutcomes
+				mockMetrics.MetricPanics = panicCounter
+				return mockMetrics
+			},
+			eventCount:  10,
+			shouldPanic: false,
 		},
 	}
 

--- a/internal/metrics/subject_test.go
+++ b/internal/metrics/subject_test.go
@@ -22,6 +22,7 @@ func createMinimalMetrics() Metrics {
 		KafkaPublishLatency:    &MockHistogram{},
 		Panics:                 &MockCounter{},
 		UnknownMetrics:         &MockCounter{},
+		MetricPanics:           &MockCounter{},
 	}
 }
 

--- a/internal/metrics/subject_test.go
+++ b/internal/metrics/subject_test.go
@@ -21,6 +21,7 @@ func createMinimalMetrics() Metrics {
 		KafkaPublished:         &MockCounter{},
 		KafkaPublishLatency:    &MockHistogram{},
 		Panics:                 &MockCounter{},
+		UnknownMetrics:         &MockCounter{},
 	}
 }
 
@@ -121,13 +122,17 @@ func TestSubjectNotify(t *testing.T) {
 			verifyMocks: true,
 		},
 		{
-			name: "unknown metric name ignored",
+			name: "unknown metric tracked by unknown metrics observer",
 			setupMetrics: func() (Metrics, []string) {
 				counter := &MockCounter{}
-				// No expectations set - methods should not be called
+				unknownCounter := &MockCounter{}
+				// Set up expectations for unknown metrics tracking
+				unknownCounter.On("With", []string{"metric_name", "unknown_metric_name", "metric_type", "unknown"}).Return(unknownCounter)
+				unknownCounter.On("Add", 1.0).Return()
 
 				mockMetrics := createMinimalMetrics()
 				mockMetrics.ConsumerFetchErrors = counter
+				mockMetrics.UnknownMetrics = unknownCounter
 				return mockMetrics, []string{}
 			},
 			event: Event{
@@ -136,7 +141,7 @@ func TestSubjectNotify(t *testing.T) {
 				Value:  10.0,
 			},
 			useSync:     false,
-			verifyMocks: false, // No mock calls expected
+			verifyMocks: true, // Now we expect calls to unknown metrics
 		},
 	}
 
@@ -180,10 +185,9 @@ func TestSubjectNotify(t *testing.T) {
 					}
 				}
 			} else if tt.event.Name == "unknown_metric_name" {
-				// Verify counter was never called for unknown metrics
-				if counter, ok := mockMetrics.ConsumerFetchErrors.(*MockCounter); ok {
-					counter.AssertNotCalled(t, "With")
-					counter.AssertNotCalled(t, "Add")
+				// Verify unknown metrics counter was called
+				if unknownCounter, ok := mockMetrics.UnknownMetrics.(*MockCounter); ok {
+					unknownCounter.AssertExpectations(t)
 				}
 			}
 		})


### PR DESCRIPTION
Closes #77 

Instead of creating separate observers for every metric, this creates only three Metric Observers, one for each:
- Counters
- Histograms
- Gauges