### PR TITLE
use a shared custom registry for app + franz-go metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/twmb/franz-go/plugin/kprom v1.3.0
 	github.com/xmidt-org/httpaux v0.4.3
 	github.com/xmidt-org/wrp-go/v5 v5.4.1
-	github.com/xmidt-org/wrpkafka v0.1.6
+	github.com/xmidt-org/wrpkafka v0.1.7
 	go.uber.org/fx v1.24.0
 	gopkg.in/dealancer/validate.v2 v2.1.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/xmidt-org/wrp-go/v3 v3.7.0 h1:m9ghdq79Zzb0WjomUJ02rzFpI0RK8KTjArYpNIw
 github.com/xmidt-org/wrp-go/v3 v3.7.0/go.mod h1:eyMj+q/7LQ4SU6Z3s6VOwuTVSh6/DJBb2soBGBFSung=
 github.com/xmidt-org/wrp-go/v5 v5.4.1 h1:znfW35ur+YhdpSIv2a6UpAnbwV5xh/6pFUAIVeAo0E4=
 github.com/xmidt-org/wrp-go/v5 v5.4.1/go.mod h1:ccLAyLFWYRAtg9kDi2M3cFU+RwsakHCMTogsPyh5EBw=
-github.com/xmidt-org/wrpkafka v0.1.6 h1:hT0aLG3RzURKbTC5LVdTWv2YRp768VOjWX4q+GIk1NM=
-github.com/xmidt-org/wrpkafka v0.1.6/go.mod h1:ZAp387QesZko0uPbH4T/3K6Of1f+FhZgrQw0HPije1s=
+github.com/xmidt-org/wrpkafka v0.1.7 h1:y5znySNmkFAVQqbXE1GNrCTAd6zlhaWLOfuV3kUsgtE=
+github.com/xmidt-org/wrpkafka v0.1.7/go.mod h1:ZAp387QesZko0uPbH4T/3K6Of1f+FhZgrQw0HPije1s=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/goschtalt/goschtalt/pkg/typical"
 	_ "github.com/goschtalt/yaml-decoder"
 	_ "github.com/goschtalt/yaml-encoder"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -564,10 +565,11 @@ func TestProvideConsumer(t *testing.T) {
 						DefaultNamespace: "xmidt",
 						DefaultSubsystem: "test",
 					},
-					Publisher:     createValidKafkaPublisher(),
-					LogEmitter:    logEmitter,
-					MetricEmitter: metricEmitter,
-					Buckets:       createValidBucket(),
+					PrometheusRegisterer: prometheus.NewRegistry(),
+					Publisher:            createValidKafkaPublisher(),
+					LogEmitter:           logEmitter,
+					MetricEmitter:        metricEmitter,
+					Buckets:              createValidBucket(),
 				}
 			},
 			expectError: false,
@@ -590,10 +592,11 @@ func TestProvideConsumer(t *testing.T) {
 						DefaultNamespace: "xmidt",
 						DefaultSubsystem: "test",
 					},
-					Publisher:     createValidKafkaPublisher(),
-					LogEmitter:    logEmitter,
-					MetricEmitter: metricEmitter,
-					Buckets:       createValidBucket(),
+					PrometheusRegisterer: prometheus.NewRegistry(),
+					Publisher:            createValidKafkaPublisher(),
+					LogEmitter:           logEmitter,
+					MetricEmitter:        metricEmitter,
+					Buckets:              createValidBucket(),
 				}
 			},
 			expectError: true,

--- a/internal/app/consumer.go
+++ b/internal/app/consumer.go
@@ -13,19 +13,21 @@ import (
 	"xmidt-org/splitter/internal/observe"
 	"xmidt-org/splitter/internal/publisher"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/xmidt-org/touchstone"
 	"go.uber.org/fx"
 )
 
 type ConsumerIn struct {
 	fx.In
-	Config           consumer.Config
-	BucketConfig     bucket.Config
-	PrometheusConfig touchstone.Config
-	Publisher        publisher.Publisher
-	LogEmitter       *observe.Subject[log.Event]
-	MetricEmitter    *observe.Subject[metrics.Event]
-	Buckets          bucket.Bucket
+	Config               consumer.Config
+	BucketConfig         bucket.Config
+	PrometheusConfig     touchstone.Config
+	PrometheusRegisterer prometheus.Registerer
+	Publisher            publisher.Publisher
+	LogEmitter           *observe.Subject[log.Event]
+	MetricEmitter        *observe.Subject[metrics.Event]
+	Buckets              bucket.Bucket
 }
 
 type ConsumerOut struct {
@@ -55,7 +57,7 @@ func provideConsumer(in ConsumerIn) (ConsumerOut, error) {
 	opts := []consumer.Option{
 		// Observability
 		consumer.WithLogEmitter(in.LogEmitter),
-		consumer.WithPrometheusMetrics(in.PrometheusConfig.DefaultNamespace, in.PrometheusConfig.DefaultSubsystem),
+		consumer.WithPrometheusMetrics(in.PrometheusConfig.DefaultNamespace, in.PrometheusConfig.DefaultSubsystem, in.PrometheusRegisterer),
 		consumer.WithMetricsEmitter(in.MetricEmitter),
 
 		// Required options

--- a/internal/app/consumer.go
+++ b/internal/app/consumer.go
@@ -57,7 +57,7 @@ func provideConsumer(in ConsumerIn) (ConsumerOut, error) {
 	opts := []consumer.Option{
 		// Observability
 		consumer.WithLogEmitter(in.LogEmitter),
-		consumer.WithPrometheusMetrics(in.PrometheusConfig.DefaultNamespace, in.PrometheusConfig.DefaultSubsystem, in.PrometheusRegisterer),
+		consumer.WithPrometheusMetrics(in.PrometheusConfig.DefaultNamespace, in.PrometheusConfig.DefaultSubsystem+"_consumer", in.PrometheusRegisterer),
 		consumer.WithMetricsEmitter(in.MetricEmitter),
 
 		// Required options

--- a/internal/app/publisher.go
+++ b/internal/app/publisher.go
@@ -11,6 +11,7 @@ import (
 	"xmidt-org/splitter/internal/observe"
 	"xmidt-org/splitter/internal/publisher"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/xmidt-org/touchstone"
 	"go.uber.org/fx"
 )
@@ -18,10 +19,11 @@ import (
 // PublisherIn contains the dependencies needed to create a publisher instance.
 type PublisherIn struct {
 	fx.In
-	Config           publisher.Config
-	LogEmitter       *observe.Subject[log.Event]
-	MetricEmitter    *observe.Subject[metrics.Event]
-	PrometheusConfig touchstone.Config
+	Config               publisher.Config
+	LogEmitter           *observe.Subject[log.Event]
+	MetricEmitter        *observe.Subject[metrics.Event]
+	PrometheusConfig     touchstone.Config
+	PrometheusRegisterer prometheus.Registerer
 }
 
 // PublisherOut contains the created publisher instance.
@@ -66,7 +68,7 @@ func providePublisher(in PublisherIn) (PublisherOut, error) {
 		publisher.WithTLSConfig(cfg.TLS),
 
 		// configure franz-go to emit prometheus metrics with the provided namespace and subsystem
-		publisher.WithPrometheusMetrics(prometheusCfg.DefaultNamespace, prometheusCfg.DefaultSubsystem),
+		publisher.WithPrometheusMetrics(prometheusCfg.DefaultNamespace, prometheusCfg.DefaultSubsystem+"_publisher", in.PrometheusRegisterer),
 	}
 
 	// Create the publisher

--- a/internal/app/service_modules.go
+++ b/internal/app/service_modules.go
@@ -52,6 +52,9 @@ func ObservabilityModule() fx.Option {
 		),
 
 		// Prometheus metrics setup
+		// touchstone.Provide() creates a prometheus.Registry and provides it as both
+		// *touchstone.Factory and prometheus.Registerer, which allows franz-go to
+		// register metrics in the same registry used by touchstone
 		fx.Provide(
 			goschtalt.UnmarshalFunc[touchstone.Config]("prometheus"),
 			goschtalt.UnmarshalFunc[touchhttp.Config]("prometheus_handler"),

--- a/internal/consumer/options.go
+++ b/internal/consumer/options.go
@@ -16,6 +16,7 @@ import (
 	"xmidt-org/splitter/internal/metrics"
 	"xmidt-org/splitter/internal/observe"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sasl/plain"
 	"github.com/twmb/franz-go/pkg/sasl/scram"
@@ -432,7 +433,13 @@ func (s *slogAdapter) Log(level kgo.LogLevel, msg string, keyvals ...interface{}
 
 // WithPrometheusMetrics configures franz-go to emit Prometheus metrics.
 // This uses the kprom plugin to register metrics with the provided namespace and subsystem.
-// Metrics will be automatically registered with the default Prometheus registry.
+// The registerer parameter allows you to specify which Prometheus registry to use.
+// If registerer is nil, metrics will be registered with the default Prometheus registry.
+//
+// IMPORTANT: If your application uses touchstone or a custom Prometheus registry,
+// you must pass that registry's Registerer to ensure metrics appear in your
+// metrics endpoint. Otherwise, metrics will be registered with the global registry
+// and won't be scraped.
 //
 // Example metrics exposed:
 //   - {namespace}_{subsystem}_records_consumed_total
@@ -442,7 +449,7 @@ func (s *slogAdapter) Log(level kgo.LogLevel, msg string, keyvals ...interface{}
 //   - And many more...
 //
 // For full list of metrics, see: https://pkg.go.dev/github.com/twmb/franz-go/plugin/kprom
-func WithPrometheusMetrics(namespace, subsystem string) Option {
+func WithPrometheusMetrics(namespace, subsystem string, registerer prometheus.Registerer) Option {
 	return optionFunc(func(c *KafkaConsumer) error {
 		if namespace == "" {
 			return fmt.Errorf("metrics namespace cannot be empty")
@@ -452,11 +459,18 @@ func WithPrometheusMetrics(namespace, subsystem string) Option {
 			return fmt.Errorf("metrics subsystem cannot be empty")
 		}
 
-		// Create kprom metrics with the specified namespace and subsystem
-		metrics := kprom.NewMetrics(
-			namespace,
+		// Build kprom options
+		kpromOpts := []kprom.Opt{
 			kprom.Subsystem(subsystem),
-		)
+		}
+
+		// If a custom registerer is provided, use it instead of the default
+		if registerer != nil {
+			kpromOpts = append(kpromOpts, kprom.Registerer(registerer))
+		}
+
+		// Create kprom metrics with the specified namespace and subsystem
+		metrics := kprom.NewMetrics(namespace, kpromOpts...)
 
 		// Add the metrics hook to the consumer
 		c.config.kgoOpts = append(c.config.kgoOpts, kgo.WithHooks(metrics))

--- a/internal/consumer/options_test.go
+++ b/internal/consumer/options_test.go
@@ -562,7 +562,7 @@ func (s *OptionsTestSuite) TestWithLogEmitter_Nil() {
 
 func (s *OptionsTestSuite) TestWithPrometheusMetrics() {
 	consumer, err := s.createTestConsumer(
-		WithPrometheusMetrics("test_namespace", "test_subsystem"),
+		WithPrometheusMetrics("test_namespace", "test_subsystem", nil),
 	)
 	s.NoError(err)
 	s.NotNil(consumer)
@@ -571,7 +571,7 @@ func (s *OptionsTestSuite) TestWithPrometheusMetrics() {
 
 func (s *OptionsTestSuite) TestWithPrometheusMetrics_EmptyNamespace() {
 	consumer, err := s.createTestConsumer(
-		WithPrometheusMetrics("", "subsystem"),
+		WithPrometheusMetrics("", "subsystem", nil),
 	)
 	s.Error(err)
 	s.Nil(consumer)
@@ -580,7 +580,7 @@ func (s *OptionsTestSuite) TestWithPrometheusMetrics_EmptyNamespace() {
 
 func (s *OptionsTestSuite) TestWithPrometheusMetrics_EmptySubsystem() {
 	consumer, err := s.createTestConsumer(
-		WithPrometheusMetrics("namespace", ""),
+		WithPrometheusMetrics("namespace", "", nil),
 	)
 	s.Error(err)
 	s.Nil(consumer)

--- a/internal/consumer/options_test.go
+++ b/internal/consumer/options_test.go
@@ -16,6 +16,7 @@ import (
 	"xmidt-org/splitter/internal/metrics"
 
 	kit "github.com/go-kit/kit/metrics"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/suite"
 	"github.com/twmb/franz-go/pkg/kgo"
 )
@@ -585,6 +586,18 @@ func (s *OptionsTestSuite) TestWithPrometheusMetrics_EmptySubsystem() {
 	s.Error(err)
 	s.Nil(consumer)
 	s.Contains(err.Error(), "subsystem cannot be empty")
+}
+
+func (s *OptionsTestSuite) TestWithPrometheusMetrics_CustomRegistry() {
+	// Create a custom prometheus registry
+	customRegistry := prometheus.NewRegistry()
+
+	consumer, err := s.createTestConsumer(
+		WithPrometheusMetrics("custom_namespace", "custom_subsystem", customRegistry),
+	)
+	s.NoError(err)
+	s.NotNil(consumer)
+	s.NotEmpty(consumer.config.kgoOpts)
 }
 
 func (s *OptionsTestSuite) TestWithMetricsEmitter() {

--- a/internal/publisher/config_test.go
+++ b/internal/publisher/config_test.go
@@ -485,7 +485,7 @@ func (suite *OptionsTestSuite) TestOptions() {
 		},
 		{
 			name:   "WithPrometheusMetrics_both_values",
-			option: WithPrometheusMetrics("xmidt", "splitter"),
+			option: WithPrometheusMetrics("xmidt", "splitter", nil),
 			setupPub: func() *KafkaPublisher {
 				return &KafkaPublisher{config: &publisherConfig{}}
 			},
@@ -497,7 +497,7 @@ func (suite *OptionsTestSuite) TestOptions() {
 		},
 		{
 			name:   "WithPrometheusMetrics_empty_values",
-			option: WithPrometheusMetrics("", ""),
+			option: WithPrometheusMetrics("", "", nil),
 			setupPub: func() *KafkaPublisher {
 				return &KafkaPublisher{config: &publisherConfig{}}
 			},
@@ -509,7 +509,7 @@ func (suite *OptionsTestSuite) TestOptions() {
 		},
 		{
 			name:   "WithPrometheusMetrics_namespace_only",
-			option: WithPrometheusMetrics("monitoring", ""),
+			option: WithPrometheusMetrics("monitoring", "", nil),
 			setupPub: func() *KafkaPublisher {
 				return &KafkaPublisher{config: &publisherConfig{}}
 			},
@@ -521,7 +521,7 @@ func (suite *OptionsTestSuite) TestOptions() {
 		},
 		{
 			name:   "WithPrometheusMetrics_subsystem_only",
-			option: WithPrometheusMetrics("", "kafka"),
+			option: WithPrometheusMetrics("", "kafka", nil),
 			setupPub: func() *KafkaPublisher {
 				return &KafkaPublisher{config: &publisherConfig{}}
 			},

--- a/internal/publisher/options.go
+++ b/internal/publisher/options.go
@@ -15,6 +15,7 @@ import (
 	"xmidt-org/splitter/internal/metrics"
 	"xmidt-org/splitter/internal/observe"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/sasl"
 	"github.com/twmb/franz-go/pkg/sasl/plain"
@@ -59,6 +60,7 @@ type publisherConfig struct {
 	publishEventListeners  []func(*wrpkafka.PublishEvent)
 	prometheusNamespace    string
 	prometheusSubsystem    string
+	prometheusRegisterer   prometheus.Registerer
 }
 
 // validate ensures all required configuration is present.
@@ -308,10 +310,11 @@ func WithTLS() Option {
 	return WithTLSConfig(&TLSConfig{Enabled: true})
 }
 
-func WithPrometheusMetrics(namespace, subsystem string) Option {
+func WithPrometheusMetrics(namespace, subsystem string, registerer prometheus.Registerer) Option {
 	return optionFunc(func(p *KafkaPublisher) error {
 		p.config.prometheusNamespace = namespace
 		p.config.prometheusSubsystem = subsystem
+		p.config.prometheusRegisterer = registerer
 		return nil
 	})
 }

--- a/internal/publisher/publisher.go
+++ b/internal/publisher/publisher.go
@@ -84,6 +84,7 @@ func New(opts ...Option) (*KafkaPublisher, error) {
 		InitialPublishEventListeners: publisher.config.publishEventListeners,
 		PrometheusNamespace:          publisher.config.prometheusNamespace,
 		PrometheusSubsystem:          publisher.config.prometheusSubsystem,
+		PrometheusRegisterer:         publisher.config.prometheusRegisterer,
 	}
 
 	publisher.wrpPublisher = wrpPublisher

--- a/internal/publisher/publisher_test.go
+++ b/internal/publisher/publisher_test.go
@@ -185,7 +185,7 @@ func (suite *PublisherTestSuite) TestNew() {
 			options: []Option{
 				WithBrokers(testBroker),
 				WithTopicRoutes(wrpkafka.TopicRoute{Topic: "test", Pattern: ".*"}),
-				WithPrometheusMetrics("xmidt", "splitter"),
+				WithPrometheusMetrics("xmidt", "splitter", nil),
 			},
 			expectError: false,
 			description: "Should create publisher with Prometheus metrics configuration",
@@ -195,7 +195,7 @@ func (suite *PublisherTestSuite) TestNew() {
 			options: []Option{
 				WithBrokers(testBroker),
 				WithTopicRoutes(wrpkafka.TopicRoute{Topic: "test", Pattern: ".*"}),
-				WithPrometheusMetrics("", ""),
+				WithPrometheusMetrics("", "", nil),
 			},
 			expectError: false,
 			description: "Should create publisher with empty Prometheus namespace and subsystem",
@@ -273,7 +273,7 @@ func (suite *PublisherTestSuite) TestPrometheusMetricsConfiguration() {
 			publisher, err := New(
 				WithBrokers(testBroker),
 				WithTopicRoutes(wrpkafka.TopicRoute{Topic: "test", Pattern: ".*"}),
-				WithPrometheusMetrics(tt.namespace, tt.subsystem),
+				WithPrometheusMetrics(tt.namespace, tt.subsystem, nil),
 			)
 
 			suite.NoError(err, tt.description)


### PR DESCRIPTION
franz-go metrics were nowhere to be found because they were being registered on the default prometheus registry