### PR TITLE
Bypass standard validation for wrp in wrp-go V5 during Decoding

### DIFF
--- a/internal/consumer/handler.go
+++ b/internal/consumer/handler.go
@@ -110,7 +110,7 @@ func (h *WRPMessageHandler) HandleMessage(ctx context.Context, record *kgo.Recor
 
 	// Decode WRP message
 	var msg wrp.Message
-	if err := wrp.NewDecoderBytes(record.Value, wrp.Msgpack).Decode(&msg); err != nil {
+	if err := wrp.NewDecoderBytes(record.Value, wrp.Msgpack).Decode(&msg, wrp.NoStandardValidation()); err != nil {
 
 		// Log the error and the malformed message
 		h.emitLog(log.LevelWarn, "decode WRP message", map[string]any{

--- a/internal/consumer/handler_test.go
+++ b/internal/consumer/handler_test.go
@@ -54,7 +54,7 @@ func (suite *HandlerTestSuite) TestHandleMessage_NotInTargetBucket() {
 	msg := createValidWrpMsg()
 	var buf bytes.Buffer
 	enc := wrp.NewEncoder(&buf, wrp.Msgpack)
-	_ = enc.Encode(msg)
+	_ = enc.Encode(msg, wrp.NoStandardValidation())
 	b := buf.Bytes()
 	suite.buckets.On("IsInTargetBucket", mock.Anything).Return(false, nil).Once()
 	record := &kgo.Record{Value: b}
@@ -68,7 +68,7 @@ func (suite *HandlerTestSuite) TestHandleMessage_ProduceError() {
 	msg := createValidWrpMsg()
 	var buf bytes.Buffer
 	enc := wrp.NewEncoder(&buf, wrp.Msgpack)
-	_ = enc.Encode(msg)
+	_ = enc.Encode(msg, wrp.NoStandardValidation())
 	b := buf.Bytes()
 	suite.buckets.On("IsInTargetBucket", mock.Anything).Return(true, nil).Once()
 	suite.producer.On("Produce", mock.Anything, mock.Anything).Return(wrpkafka.Failed, errors.New("produce fail")).Once()
@@ -84,7 +84,29 @@ func (suite *HandlerTestSuite) TestHandleMessage_Success() {
 	msg := createValidWrpMsg()
 	var buf bytes.Buffer
 	enc := wrp.NewEncoder(&buf, wrp.Msgpack)
-	_ = enc.Encode(msg)
+	_ = enc.Encode(msg, wrp.NoStandardValidation())
+	b := buf.Bytes()
+	suite.buckets.On("IsInTargetBucket", mock.Anything).Return(true, nil).Once()
+	suite.producer.On("Produce", mock.Anything, mock.Anything).Return(wrpkafka.Attempted, nil).Once()
+	record := &kgo.Record{Value: b}
+	outcome, err := suite.handler.HandleMessage(context.Background(), record)
+	assert.NoError(suite.T(), err)
+	assert.Equal(suite.T(), Attempted, outcome)
+	suite.buckets.AssertExpectations(suite.T())
+	suite.producer.AssertExpectations(suite.T())
+}
+
+func (suite *HandlerTestSuite) TestHandleMessage_SuccessWithNoStandardValidation() {
+	// Test that source value gets decoded successfully even if it doesn't conform to standard WRP validation rules, since we're using NoStandardValidation.
+	msg := &wrp.Message{
+		Type:        wrp.SimpleEventMessageType,
+		Source:      "mac:FAKEMAC",
+		Destination: "event:device-status/mac:d89c8e3a28e8/offline",
+		Payload:     []byte(`{"test":"data"}`),
+	}
+	var buf bytes.Buffer
+	enc := wrp.NewEncoder(&buf, wrp.Msgpack)
+	_ = enc.Encode(msg, wrp.NoStandardValidation())
 	b := buf.Bytes()
 	suite.buckets.On("IsInTargetBucket", mock.Anything).Return(true, nil).Once()
 	suite.producer.On("Produce", mock.Anything, mock.Anything).Return(wrpkafka.Attempted, nil).Once()


### PR DESCRIPTION
Fixes https://github.com/comcast-cl/xmidt/issues/5986

`wrp-go v5` automatically applies `StandardValidator() `during `NewDecoderBytes()` (and encoding) unlike `v3` which requires the validator to be called explicitly. Some wrp messages cause errors during decoding due to improperly formatted `source` fields. We want to bypass the validation at this time.